### PR TITLE
Don't panic if the given offset is longer than the file length

### DIFF
--- a/cmd/fillstruct/main.go
+++ b/cmd/fillstruct/main.go
@@ -302,7 +302,11 @@ func main() {
 	}
 	pkg := lprog.InitialPackages()[0]
 
-	f, pos := findPos(lprog, path, *offset)
+	f, pos, err := findPos(lprog, path, *offset)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	lit, typ, name, err := findCompositeLit(f, pkg.Info, pos)
 	if err != nil {
 		log.Fatal(err)
@@ -352,13 +356,19 @@ func load(path string, modified bool) (*loader.Program, error) {
 	return conf.Load()
 }
 
-func findPos(lprog *loader.Program, filename string, off int) (*ast.File, token.Pos) {
+func findPos(lprog *loader.Program, filename string, off int) (*ast.File, token.Pos, error) {
 	for _, f := range lprog.InitialPackages()[0].Files {
 		if file := lprog.Fset.File(f.Pos()); file.Name() == filename {
-			return f, file.Pos(off)
+			if off > file.Size() {
+				return nil, 0,
+					fmt.Errorf("file size (%v) is smaller than given offset (%v)",
+						file.Size(), off)
+			}
+			return f, file.Pos(off), nil
 		}
 	}
-	panic("could not find file")
+
+	return nil, 0, fmt.Errorf("could not find file %#v", filename)
 }
 
 func findCompositeLit(f *ast.File, info types.Info, pos token.Pos) (*ast.CompositeLit, *types.Struct, *types.Named, error) {

--- a/cmd/fillstruct/main.go
+++ b/cmd/fillstruct/main.go
@@ -361,14 +361,14 @@ func findPos(lprog *loader.Program, filename string, off int) (*ast.File, token.
 		if file := lprog.Fset.File(f.Pos()); file.Name() == filename {
 			if off > file.Size() {
 				return nil, 0,
-					fmt.Errorf("file size (%v) is smaller than given offset (%v)",
+					fmt.Errorf("file size (%d) is smaller than given offset (%d)",
 						file.Size(), off)
 			}
 			return f, file.Pos(off), nil
 		}
 	}
 
-	return nil, 0, fmt.Errorf("could not find file %#v", filename)
+	return nil, 0, fmt.Errorf("could not find file %q", filename)
 }
 
 func findCompositeLit(f *ast.File, info types.Info, pos token.Pos) (*ast.CompositeLit, *types.Struct, *types.Named, error) {


### PR DESCRIPTION
Give a friendly error message instead.

	$ fillstruct -file main.go -offset 9999999
	panic: illegal file offset

	goroutine 1 [running]:
	go/token.(*File).Pos(0xc420100000, 0x98967f, 0xc42001a0f0)
		/usr/lib/go/src/go/token/position.go:239 +0x62
	main.findPos(0xc4200543c0, 0xc42001a0f0, 0x4a, 0x98967f, 0x0, 0x0)
		/home/martin/go/src/github.com/davidrjenni/reftools/cmd/fillstruct/main.go:358 +0x106
	main.main()
		/home/martin/go/src/github.com/davidrjenni/reftools/cmd/fillstruct/main.go:305 +0x2ef

is now:

	$ fillstruct -file main.go -offset 9999999
	fillstruct: file size (9733) is smaller than given offset (9999999)