### PR TITLE
cmd/fillstruct: omit element type inside array, slice or map literals.

### DIFF
--- a/cmd/fillstruct/main_test.go
+++ b/cmd/fillstruct/main_test.go
@@ -517,7 +517,7 @@ type otherStruct struct {
 		pkg, lit, typ := parseStruct(t, test.name, test.src)
 
 		name := types.NewNamed(types.NewTypeName(0, pkg, "myStruct", nil), typ, nil)
-		newlit, lines := zeroValue(pkg, lit, typ, name)
+		newlit, lines := zeroValue(pkg, lit, litInfo{typ: typ, name: name})
 
 		out := printNode(t, test.name, newlit, lines)
 		if test.want != out {


### PR DESCRIPTION
If fillstruct is invoked on a struct literal inside an array, slice or
map literal, the element type is omitted.

Example: if fillstruct is invoked at the line indicated by the comment

	_ = []struct {
		a int
		b string
	}{
		{}, // fillstruct invoked here
	}

it produces the following snippet:

	_ = []struct {
		a int
		b string
	}{
		{
			a: 0,
			b: "",
		},
	}

instead of as before:

	_ = []struct {
		a int
		b string
	}{
		struct{a int; b string}{
			a: 0,
			b: "",
		},
	}

Fixes #11.