### PR TITLE
cmd/fillswitch: fix nil pointer dereference for emtpy switch statements.

### DIFF
--- a/cmd/fillswitch/fill.go
+++ b/cmd/fillswitch/fill.go
@@ -14,6 +14,11 @@ import (
 )
 
 func fillSwitch(pkg *loader.PackageInfo, lprog *loader.Program, swtch ast.Stmt, typ types.Type) ast.Stmt {
+	// Do not try to fill an empty switch statement (with no tag expression and therefore typ == nil).
+	if typ == nil {
+		return swtch
+	}
+
 	switch swtch := swtch.(type) {
 	case *ast.SwitchStmt:
 		existing := make(map[string]bool)

--- a/cmd/fillswitch/fill_test.go
+++ b/cmd/fillswitch/fill_test.go
@@ -24,7 +24,7 @@ func TestFillByOffset(t *testing.T) {
 		{folder: "typeswitch_5", offset: 170},
 		{folder: "broken_typeswitch", offset: 146},
 		{folder: "switch_1", offset: 78},
-		{folder: "empty_switch", offset: 34},
+		{folder: "empty_switch", offset: 51},
 		{folder: "multipkgs", offset: 75},
 	}
 
@@ -75,7 +75,7 @@ func TestFillByLine(t *testing.T) {
 		{folder: "typeswitch_5", line: 10},
 		{folder: "broken_typeswitch", line: 7},
 		{folder: "switch_1", line: 7},
-		{folder: "empty_switch", line: 4},
+		{folder: "empty_switch", line: 6},
 	}
 
 	for _, test := range tests {

--- a/cmd/fillswitch/test-fixtures/empty_switch/input.go
+++ b/cmd/fillswitch/test-fixtures/empty_switch/input.go
@@ -1,5 +1,7 @@
 package p
 
+import _ "sort"
+
 func test() {
 	switch {
 	}


### PR DESCRIPTION
Change the test case 'empty_switch' to trigger the problematic
behaviour.