### PR TITLE
cmd/fillstruct: insert empty funcs for fields of func types.

### DIFF
--- a/cmd/fillstruct/fill.go
+++ b/cmd/fillstruct/fill.go
@@ -133,7 +133,38 @@ func (f *filler) zero(info litInfo, visited []types.Type) ast.Expr {
 		f.lines += 2
 		return lit
 	case *types.Signature:
-		return &ast.Ident{Name: "nil", NamePos: f.pos}
+		params := make([]*ast.Field, t.Params().Len())
+		for i := 0; i < t.Params().Len(); i++ {
+			typeName, ok := typeString(f.pkg, f.importNames, t.Params().At(i).Type())
+			if !ok {
+				return nil
+			}
+			params[i] = &ast.Field{
+				Type: ast.NewIdent(typeName),
+			}
+		}
+		results := make([]*ast.Field, t.Results().Len())
+		for i := 0; i < t.Results().Len(); i++ {
+			typeName, ok := typeString(f.pkg, f.importNames, t.Results().At(i).Type())
+			if !ok {
+				return nil
+			}
+			results[i] = &ast.Field{
+				Type: ast.NewIdent(typeName),
+			}
+		}
+		return &ast.FuncLit{
+			Type: &ast.FuncType{
+				Func:    f.pos,
+				Params:  &ast.FieldList{List: params},
+				Results: &ast.FieldList{List: results},
+			},
+			Body: &ast.BlockStmt{
+				List: []ast.Stmt{
+					&ast.ExprStmt{X: ast.NewIdent(`panic("not implemented")`)},
+				},
+			},
+		}
 	case *types.Slice:
 		return &ast.Ident{Name: "nil", NamePos: f.pos}
 

--- a/cmd/fillstruct/fill_test.go
+++ b/cmd/fillstruct/fill_test.go
@@ -72,7 +72,7 @@ type myStruct struct {
 }`,
 		},
 		{
-			name: "all nil",
+			name: "basic composite types",
 			src: `package p
 
 import "io"
@@ -90,7 +90,7 @@ type myStruct struct {
 	a: nil,
 	c: nil,
 	d: nil,
-	f: nil,
+	f: func(int) bool { panic("not implemented") },
 	g: nil,
 }`,
 		},
@@ -161,20 +161,23 @@ import "io"
 var s = myStruct{}
 
 type (
-	integer int64
-	reader io.Reader
-	slice []int
+	integer  int64
+	reader   io.Reader
+	slice    []integer
+	functype func(reader) func(int) bool
 )
 
 type myStruct struct {
 	a integer
 	b reader
 	c slice
+	f functype
 }`,
 			want: `myStruct{
 	a: 0,
 	b: nil,
 	c: nil,
+	f: func(reader) func(int) bool { panic("not implemented") },
 }`,
 		},
 		{
@@ -256,9 +259,9 @@ type myStruct struct {
 		make(<-chan struct{}),
 	},
 	d: [3]func(struct{}, interface{}) bool{
-		nil,
-		nil,
-		nil,
+		func(struct{}, interface{}) bool { panic("not implemented") },
+		func(struct{}, interface{}) bool { panic("not implemented") },
+		func(struct{}, interface{}) bool { panic("not implemented") },
 	},
 	e: [2][2][]unsafe.Pointer{
 		{


### PR DESCRIPTION
Before, fillstruct inserted `nil`.