### PR TITLE
cmd/fillstruct: Do not populate gRPC system field. Fixes #34

### DIFF
--- a/cmd/fillstruct/fill.go
+++ b/cmd/fillstruct/fill.go
@@ -10,6 +10,7 @@ import (
 	"go/token"
 	"go/types"
 	"strconv"
+	"strings"
 )
 
 // litInfo contains the information about
@@ -243,6 +244,10 @@ func (f *filler) zero(info litInfo, visited []types.Type) ast.Expr {
 
 		for i := 0; i < t.NumFields(); i++ {
 			field := t.Field(i)
+			// don't fill the field if it a gRPC system field
+			if strings.HasPrefix(field.Name(), "XXX_") {
+				continue
+			}
 			if kv, ok := f.existing[field.Name()]; first && ok {
 				f.pos++
 				lines++

--- a/cmd/fillstruct/fill_test.go
+++ b/cmd/fillstruct/fill_test.go
@@ -571,6 +571,24 @@ type myStruct struct {
 		N: 0,
 	},
 }`,
+		}, {
+			name: "gRPC types",
+			src: `package p
+
+import "unsafe"
+
+var s = myStruct{}
+
+type myStruct struct {
+	Name                 string
+	XXX_NoUnkeyedLiteral struct{}
+	XXX_unrecognized     []byte
+	XXX_sizecache        int32
+	XXX_whatever         string
+}`,
+			want: `myStruct{
+	Name: "",
+}`,
 		},
 	}
 


### PR DESCRIPTION
this fixes the referenced issues concerning gRPC/protoc generated code. As stated in the issues these field are gRPC implementation detail and the user rarely if ever interacts with them.

For the implentation I chose to decide whether a field should be ignored or not by checking whether it starts with `XXX_`. This has a realllllly small change of yielding a false positive if one names his field something `XXX_Name` or something of the sort, but who names its fields like that, right? If we want to be 100% sure that this will not happen we could do something like:
```golang
var (
	grpcFields = []string{"XXX_NoUnkeyedLiteral", "XXX_unrecognized", "XXX_sizecache"}
)

func isGRPCField(f string) bool {
    for _, a := range grpcFields {
        if a == f {
            return true
        }
    }
    return false
}

func (f *filler) zero(info litInfo, visited []types.Type) ast.Expr {
    // code
    if isGRPCField(field.Name()){
        continue;
    }
    // more code
}
```

I have decided that doing this will be an overkill, but can easily add it to PR if you think this is the better approach.

I have added a test scenario for this, and also ran the code locally. This was the output: 
```sh
➜  fillstruct git:(grpc_field) ✗ bat new.go
───────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: new.go
───────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ package main
   2   │ 
   3   │ type grpcGenStr struct {
   4   │     Name                 string
   5   │     XXX_NoUnkeyedLiteral struct{}
   6   │     XXX_unrecognized     []byte
   7   │     XXX_sizecache        int32
   8   │     XXX_whatever         string
   9   │ }
  10   │ 
  11   │ func test() {
  12   │     g := grpcGenStr{}
  13   │ }
───────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
➜  fillstruct git:(grpc_field) ✗ ./fillstruct -file="new.go" -line=12
[{"start":208,"end":220,"code":"grpcGenStr{\n\tName: \"\",\n}"}]`