### PR TITLE
Fill slice as empty slice, not nil

### DIFF
--- a/cmd/fillstruct/fill.go
+++ b/cmd/fillstruct/fill.go
@@ -165,8 +165,21 @@ func (f *filler) zero(info litInfo, visited []types.Type) ast.Expr {
 			},
 		}
 	case *types.Slice:
-		return &ast.Ident{Name: "nil", NamePos: f.pos}
-
+		lit := &ast.CompositeLit{Lbrace: f.pos}
+		if !info.hideType {
+			typeName, ok := typeString(f.pkg, f.importNames, t.Elem())
+			if !ok {
+				return nil
+			}
+			lit.Type = &ast.ArrayType{
+				Lbrack: f.pos,
+				Elt:    ast.NewIdent(typeName),
+			}
+		}
+		f.lines += 2
+		f.pos++
+		lit.Rbrace = f.pos
+		return lit
 	case *types.Array:
 		lit := &ast.CompositeLit{Lbrace: f.pos}
 		if !info.hideType {

--- a/cmd/fillstruct/fill_test.go
+++ b/cmd/fillstruct/fill_test.go
@@ -91,7 +91,7 @@ type myStruct struct {
 	c: nil,
 	d: nil,
 	f: func(int) bool { panic("not implemented") },
-	g: nil,
+	g: []int{},
 }`,
 		},
 		{
@@ -176,7 +176,7 @@ type myStruct struct {
 			want: `myStruct{
 	a: 0,
 	b: nil,
-	c: nil,
+	c: []integer{},
 	f: func(reader) func(int) bool { panic("not implemented") },
 }`,
 		},
@@ -265,12 +265,12 @@ type myStruct struct {
 	},
 	e: [2][2][]unsafe.Pointer{
 		{
-			nil,
-			nil,
+			{},
+			{},
 		},
 		{
-			nil,
-			nil,
+			{},
+			{},
 		},
 	},
 	f: [1]interface{Read(p []byte) (n int, err error); foo(unsafe.Pointer, ...int) (bool, int); io.Reader}{
@@ -428,7 +428,7 @@ type myStruct struct {
 	lit: &ast.CallExpr{
 		Fun:      nil,
 		Lparen:   0,
-		Args:     nil,
+		Args:     []ast.Expr{},
 		Ellipsis: 0,
 		Rparen:   0,
 	},
@@ -502,7 +502,7 @@ type myStruct struct {
 	a: 0,
 	c: 0,
 	e: nil,
-	f: nil,
+	f: []int{},
 }`,
 		},
 		/*


### PR DESCRIPTION
Closes #48

The logic is basically the same as the one for arrays, with the exception that we don't insert elements. ~~There is a little code duplication, but abstracting the logic into a function that handles both `types.Slice` and `types.Array` will be tricky, because the interface is different (`types.Array` has `Len()` method which we use). I am open to ideas on better approaches to this problem.~~

I am willing to address any changes or suggestions you may have about this.

**EDIT**: I think I found a way to extract the duplicated logic in a sensible way. See 8f623b5759401e267c832133ee5bd19105af720c