### PR TITLE
Update fillstruct to handle build tags

### DIFF
--- a/cmd/fillstruct/fill_test.go
+++ b/cmd/fillstruct/fill_test.go
@@ -51,6 +51,36 @@ type myStruct struct {
 }`,
 		},
 		{
+			name: "basic types with tags",
+			src: `// +build foo
+package p
+
+import "unsafe"
+
+var s = myStruct{}
+
+type myStruct struct {
+	a int
+	b bool
+	c complex64
+	d uint16
+	f float32
+	g string
+	h uintptr
+	i unsafe.Pointer
+}`,
+			want: `myStruct{
+	a: 0,
+	b: false,
+	c: (0 + 0i),
+	d: 0,
+	f: 0.0,
+	g: "",
+	h: uintptr(0),
+	i: unsafe.Pointer(uintptr(0)),
+}`,
+		},
+		{
 			name: "make",
 			src: `package p
 

--- a/cmd/fillstruct/fill_test.go
+++ b/cmd/fillstruct/fill_test.go
@@ -53,6 +53,7 @@ type myStruct struct {
 		{
 			name: "basic types with tags",
 			src: `// +build foo
+
 package p
 
 import "unsafe"

--- a/cmd/fillstruct/main.go
+++ b/cmd/fillstruct/main.go
@@ -73,6 +73,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/buildutil"
@@ -90,7 +91,9 @@ func main() {
 		modified = flag.Bool("modified", false, "read an archive of modified files from stdin")
 		offset   = flag.Int("offset", 0, "byte offset of the struct literal, optional if -line is present")
 		line     = flag.Int("line", 0, "line number of the struct literal, optional if -offset is present")
+		btags    buildutil.TagsFlag
 	)
+	flag.Var(&btags, "tags", buildutil.TagsFlagDoc)
 	flag.Parse()
 
 	if (*offset == 0 && *line == 0) || *filename == "" {
@@ -112,12 +115,13 @@ func main() {
 	}
 
 	cfg := &packages.Config{
-		Overlay: overlay,
-		Mode:    packages.LoadAllSyntax,
-		Tests:   true,
-		Dir:     filepath.Dir(path),
-		Fset:    token.NewFileSet(),
-		Env:     os.Environ(),
+		Overlay:    overlay,
+		Mode:       packages.LoadAllSyntax,
+		Tests:      true,
+		Dir:        filepath.Dir(path),
+		Fset:       token.NewFileSet(),
+		BuildFlags: []string{"-tags", strings.Join([]string(btags), ",")},
+		Env:        os.Environ(),
 	}
 
 	pkgs, err := packages.Load(cfg)


### PR DESCRIPTION
This patch allows fillstruct to generate output on destination files containing build tags cc @bhcleek